### PR TITLE
Fix compatibility with macOS Monterey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "tabox"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab8ab3e28d7ea6be57e487bf3cdb4e7c2e103eba1f01e571723ec2c86515e80"
+checksum = "6a1d713da2b9d064f12d252fce074af9e29c3c414c5994fbf451573874705bd9"
 dependencies = [
  "anyhow",
  "core_affinity",

--- a/src/tools/sandbox.rs
+++ b/src/tools/sandbox.rs
@@ -29,9 +29,6 @@ pub fn main_sandbox(opt: SandboxOpt) -> Result<(), Error> {
             .or_else(|| std::env::current_dir().ok())
             .unwrap_or_else(|| "/".into());
         config.mount(&workdir, "/box", true);
-        config.env("PATH", std::env::var("PATH").unwrap_or_default());
-        config.env("LANG", std::env::var("LANG").unwrap_or_default());
-        config.env("LC_ALL", std::env::var("LC_ALL").unwrap_or_default());
 
         config.mount(etcdir, "/etc", true);
         std::fs::write(
@@ -71,6 +68,10 @@ pub fn main_sandbox(opt: SandboxOpt) -> Result<(), Error> {
             config.mount_tmpfs(true);
         }
     }
+
+    config.env("PATH", std::env::var("PATH").unwrap_or_default());
+    config.env("LANG", std::env::var("LANG").unwrap_or_default());
+    config.env("LC_ALL", std::env::var("LC_ALL").unwrap_or_default());
 
     if let Some(memory_limit) = opt.memory_limit {
         config.memory_limit(memory_limit * 1024);

--- a/src/tools/sandbox.rs
+++ b/src/tools/sandbox.rs
@@ -1,66 +1,75 @@
+#[cfg(not(target_os = "macos"))]
 use std::path::Path;
 
 use anyhow::{Context, Error};
 use tabox::configuration::SandboxConfiguration;
 use tabox::syscall_filter::SyscallFilter;
 use tabox::{Sandbox, SandboxImplementation};
+
+#[cfg(not(target_os = "macos"))]
 use tempdir::TempDir;
 
+#[cfg(not(target_os = "macos"))]
 use task_maker_exec::sandbox::READABLE_DIRS;
 
 use crate::tools::opt::SandboxOpt;
 
 pub fn main_sandbox(opt: SandboxOpt) -> Result<(), Error> {
-    let tempdir = TempDir::new("tm-tools-sandbox")?;
-    let etcdir = tempdir.path();
-
     let mut config = SandboxConfiguration::default();
-    config.working_directory("/box");
-    let workdir = opt
-        .workdir
-        .or_else(|| std::env::current_dir().ok())
-        .unwrap_or_else(|| "/".into());
-    config.mount(&workdir, "/box", true);
-    config.env("PATH", std::env::var("PATH").unwrap_or_default());
-    config.env("LANG", std::env::var("LANG").unwrap_or_default());
-    config.env("LC_ALL", std::env::var("LC_ALL").unwrap_or_default());
 
-    config.mount(etcdir, "/etc", true);
-    std::fs::write(
-        etcdir.join("passwd"),
-        format!(
-            "root::0:0::/:/bin/sh\n\
-            nobody::{uid}:{gid}::/:/bin/sh\n",
-            uid = opt.uid,
-            gid = opt.gid,
-        ),
-    )
-    .with_context(|| format!("Failed to write /etc/etcdir in {}", etcdir.display()))?;
-    std::fs::write(
-        etcdir.join("group"),
-        format!(
-            "root:x:0:root\n\
-            nobody:x:{gid}:nobody\n",
-            gid = opt.gid,
-        ),
-    )
-    .with_context(|| format!("Failed to write /etc/group in {}", etcdir.display()))?;
+    #[cfg(not(target_os = "macos"))]
+    {
+        let tempdir = TempDir::new("tm-tools-sandbox")?;
+        let etcdir = tempdir.path();
 
-    for dir in READABLE_DIRS {
-        if Path::new(dir).is_dir() {
-            config.mount(dir, dir, false);
+        config.working_directory("/box");
+
+        let workdir = opt
+            .workdir
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_else(|| "/".into());
+        config.mount(&workdir, "/box", true);
+        config.env("PATH", std::env::var("PATH").unwrap_or_default());
+        config.env("LANG", std::env::var("LANG").unwrap_or_default());
+        config.env("LC_ALL", std::env::var("LC_ALL").unwrap_or_default());
+
+        config.mount(etcdir, "/etc", true);
+        std::fs::write(
+            etcdir.join("passwd"),
+            format!(
+                "root::0:0::/:/bin/sh\n\
+                nobody::{uid}:{gid}::/:/bin/sh\n",
+                uid = opt.uid,
+                gid = opt.gid,
+            ),
+        )
+        .with_context(|| format!("Failed to write /etc/etcdir in {}", etcdir.display()))?;
+        std::fs::write(
+            etcdir.join("group"),
+            format!(
+                "root:x:0:root\n\
+                nobody:x:{gid}:nobody\n",
+                gid = opt.gid,
+            ),
+        )
+        .with_context(|| format!("Failed to write /etc/group in {}", etcdir.display()))?;
+
+        for dir in READABLE_DIRS {
+            if Path::new(dir).is_dir() {
+                config.mount(dir, dir, false);
+            }
         }
-    }
-    for dir in &opt.readable_dirs {
-        if dir.is_dir() {
-            config.mount(dir, dir, false);
-        } else {
-            warn!("Cannot mount directory {}", dir.display());
+        for dir in &opt.readable_dirs {
+            if dir.is_dir() {
+                config.mount(dir, dir, false);
+            } else {
+                warn!("Cannot mount directory {}", dir.display());
+            }
         }
-    }
 
-    if opt.mount_tmpfs {
-        config.mount_tmpfs(true);
+        if opt.mount_tmpfs {
+            config.mount_tmpfs(true);
+        }
     }
 
     if let Some(memory_limit) = opt.memory_limit {


### PR DESCRIPTION
- update tabox to version 1.1.0
- update the `task-maker-tools sandbox` command to avoid mounting `/box` on macOS