### PR TITLE
Add async-specific DAG definition.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,6 +2373,7 @@ name = "task-maker-async"
 version = "0.1.0"
 dependencies = [
  "assert2",
+ "bincode",
  "blake3",
  "futures",
  "serde",

--- a/task-maker-async/Cargo.toml
+++ b/task-maker-async/Cargo.toml
@@ -15,5 +15,6 @@ tokio = { version = "1.14.0", features = ["full"] }
 futures = "0.3.18"
 assert2 = "0.3.6"
 blake3 = "1.3.1"
+bincode = "1.3.3"
 
 [features]

--- a/task-maker-async/src/dag.rs
+++ b/task-maker-async/src/dag.rs
@@ -3,7 +3,6 @@
 use crate::store::{DataIdentificationHash, FileSetFile, VariantIdentificationHash};
 use bincode::serialize;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
 use task_maker_dag::ExecutionCommand;
@@ -96,10 +95,11 @@ pub struct Execution {
     pub args: Vec<String>,
 
     /// All files (input, output and fifo) that are necessary for running this execution.
-    pub files: HashMap<ExecutionPath, ExecutionFileMode>,
+    /// ExecutionPath must not be repeated.
+    pub files: Vec<(ExecutionPath, ExecutionFileMode)>,
 
-    /// Environment variables to set.
-    pub env: HashMap<String, String>,
+    /// Environment variables to set (list of (Key, Value) pairs). The key must not be repeated.
+    pub env: Vec<(String, String)>,
     /// Environment variables to copy from the sandbox host.
     pub copy_env: Vec<String>,
 

--- a/task-maker-async/src/dag.rs
+++ b/task-maker-async/src/dag.rs
@@ -1,0 +1,165 @@
+#![allow(dead_code)]
+
+use crate::store::{DataIdentificationHash, FileSetFile, VariantIdentificationHash};
+use bincode::serialize;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+use task_maker_dag::ExecutionCommand;
+
+/// Higher value = executed first.
+type Priority = u32;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExecutionDAGOptions {
+    keep_sandboxes: bool,
+    priority: Priority,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecutionLimits {
+    /// Limit on the userspace cpu time of the process.
+    pub cpu_time: Option<Duration>,
+    /// Limit on the kernels pace cpu time of the process.
+    pub sys_time: Option<Duration>,
+    /// Limit on the total time of execution. This will include the io-wait time and
+    /// other non-cpu times.
+    pub wall_time: Option<Duration>,
+    /// Additional time after the time limit before killing the process.
+    pub extra_time: Option<Duration>,
+    /// Limit on the number of KiB the process can use in any moment. This can be page-aligned by
+    /// the sandbox.
+    pub memory: Option<u64>,
+    /// Limit on the number of threads/processes the process can spawn.
+    pub nproc: Option<u32>,
+    /// Limit on the number of file descriptors the process can keep open.
+    pub nofile: Option<u32>,
+    /// Maximum size of the files (in bytes) the process can write/create.
+    pub fsize: Option<u64>,
+    /// RLIMIT_MEMLOCK
+    pub memlock: Option<u64>,
+    /// Limit on the stack size for the process in KiB.
+    pub stack: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecutionConstraints {
+    /// Whether the process in the sandbox is not allowed to create new files inside the sandbox.
+    pub read_only: bool,
+    /// Whether the process in the sandbox can use `/dev/null` and `/tmp`.
+    pub mount_tmpfs: bool,
+    /// Whether the process in the sandbox can use `/proc`.
+    pub mount_proc: bool,
+    /// Extra directory that can be read inside the sandbox.
+    pub extra_readable_dirs: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+pub enum ExecutionPath {
+    Stdin,
+    Stdout,
+    Stderr,
+    Path(PathBuf),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+pub enum InputFilePermissions {
+    Default,
+    Executable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+pub enum ExecutionFileMode {
+    /// Input file to be read from the store.
+    Input(
+        DataIdentificationHash,
+        VariantIdentificationHash,
+        FileSetFile,
+        InputFilePermissions,
+    ),
+    /// Output file to be written to the store.
+    Output,
+    /// Fifo; executions within the same execution group that share the same Fifo name will share
+    /// the Fifo.
+    Fifo(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Execution {
+    /// Name of the execution, that identifies it within its execution group and is used to refer
+    /// to it.
+    pub name: String,
+    /// Which command to execute.
+    pub command: ExecutionCommand,
+    /// The list of command line arguments.
+    pub args: Vec<String>,
+
+    /// All files (input, output and fifo) that are necessary for running this execution.
+    pub files: HashMap<ExecutionPath, ExecutionFileMode>,
+
+    /// Environment variables to set.
+    pub env: HashMap<String, String>,
+    /// Environment variables to copy from the sandbox host.
+    pub copy_env: Vec<String>,
+
+    /// Limits on the execution.
+    pub limits: ExecutionLimits,
+
+    /// Other constraints on the execution
+    pub constraints: ExecutionConstraints,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExecutionGroup {
+    /// A textual description of the group.
+    pub description: String,
+
+    /// The list of executions to run.
+    pub executions: Vec<Execution>,
+
+    /// Setting this field to non-None will cause the execution to skip caching. A different string
+    /// is required for every run in which skipping the cache is desired.
+    pub skip_cache_key: Option<String>,
+
+    /// A priority index for this execution group.
+    pub priority: Priority,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExecutionDAG {
+    pub execution_groups: Vec<ExecutionGroup>,
+}
+
+impl ExecutionGroup {
+    pub fn get_data_identification_hash(&self) -> DataIdentificationHash {
+        let mut hasher = blake3::Hasher::new();
+        for ex in self.executions.iter() {
+            hasher.update(ex.name.as_bytes());
+            hasher.update(&serialize(&ex.command).unwrap());
+            hasher.update(&serialize(&ex.args).unwrap());
+            for (path, file) in ex.files.iter() {
+                hasher.update(&serialize(path).unwrap());
+                match file {
+                    ExecutionFileMode::Input(data, _, f, perm) => {
+                        hasher.update(&serialize(data).unwrap());
+                        hasher.update(&serialize(f).unwrap());
+                        hasher.update(&serialize(perm).unwrap());
+                    }
+                    _ => {
+                        hasher.update(&serialize(file).unwrap());
+                    }
+                }
+            }
+            hasher.update(&serialize(&ex.constraints).unwrap());
+        }
+        *hasher.finalize().as_bytes()
+    }
+    pub fn get_variant_identification_hash(&self) -> VariantIdentificationHash {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(self.description.as_bytes());
+        hasher.update(&serialize(&self.executions).unwrap());
+        hasher.update(&serialize(&self.skip_cache_key).unwrap());
+        *hasher.finalize().as_bytes()
+    }
+}

--- a/task-maker-async/src/dag.rs
+++ b/task-maker-async/src/dag.rs
@@ -69,14 +69,17 @@ pub enum InputFilePermissions {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+pub struct ExecutionInputFileInfo {
+    data_hash: DataIdentificationHash,
+    variant_hash: VariantIdentificationHash,
+    file_id: FileSetFile,
+    permissions: InputFilePermissions,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
 pub enum ExecutionFileMode {
     /// Input file to be read from the store.
-    Input(
-        DataIdentificationHash,
-        VariantIdentificationHash,
-        FileSetFile,
-        InputFilePermissions,
-    ),
+    Input(ExecutionInputFileInfo),
     /// Output file to be written to the store.
     Output,
     /// Fifo; executions within the same execution group that share the same Fifo name will share
@@ -141,10 +144,15 @@ impl ExecutionGroup {
             for (path, file) in ex.files.iter() {
                 hasher.update(&serialize(path).unwrap());
                 match file {
-                    ExecutionFileMode::Input(data, _, f, perm) => {
-                        hasher.update(&serialize(data).unwrap());
-                        hasher.update(&serialize(f).unwrap());
-                        hasher.update(&serialize(perm).unwrap());
+                    ExecutionFileMode::Input(ExecutionInputFileInfo {
+                        data_hash,
+                        file_id,
+                        permissions,
+                        variant_hash: _,
+                    }) => {
+                        hasher.update(&serialize(data_hash).unwrap());
+                        hasher.update(&serialize(file_id).unwrap());
+                        hasher.update(&serialize(permissions).unwrap());
                     }
                     _ => {
                         hasher.update(&serialize(file).unwrap());

--- a/task-maker-async/src/lib.rs
+++ b/task-maker-async/src/lib.rs
@@ -1,3 +1,4 @@
+mod dag;
 mod error;
 mod server;
 mod store;

--- a/task-maker-async/src/server.rs
+++ b/task-maker-async/src/server.rs
@@ -1,7 +1,7 @@
+use crate::dag::{ExecutionDAG, ExecutionDAGOptions, ExecutionGroup};
 use crate::error::Error;
 use crate::store::FileSetHandle;
 use serde::{Deserialize, Serialize};
-use task_maker_dag::{ExecutionDAGData, ExecutionGroup};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ServerStatus {
@@ -14,11 +14,11 @@ pub struct ServerStatus {
 pub trait Server {
     /// Asks the server to evaluate the given DAG. All the input files must already be available in
     /// the Store.
-    async fn evaluate(dag: ExecutionDAGData) -> Result<(), Error>;
+    async fn evaluate(dag: ExecutionDAG, options: ExecutionDAGOptions) -> Result<(), Error>;
 
     /// Asks the server for work to do. Returns a FileSetHandle to be used to store the
     /// outputs in the Store. id is an identifier of the worker that calls the method.
-    async fn get_work(id: usize) -> (ExecutionGroup, FileSetHandle);
+    async fn get_work(id: usize) -> (ExecutionGroup, ExecutionDAGOptions, FileSetHandle);
 
     /// Asks the server whether the given computation should be cancelled. Returns iff the
     /// computation should be cancelled; otherwise the request is dropped.


### PR DESCRIPTION
The async client will create an async-DAG out of a "normal" TMR DAG,
then send it to the server for execution. Once the async code is ready,
the various frontends can be converted to directly create an async-DAG.