### PR TITLE
Fix cpp::extract_includes resolving symlinks

### DIFF
--- a/task-maker-lang/src/languages/cpp.rs
+++ b/task-maker-lang/src/languages/cpp.rs
@@ -118,10 +118,6 @@ fn extract_includes(path: &Path) -> Vec<(PathBuf, PathBuf)> {
     lazy_static! {
         static ref RE: Regex = Regex::new(r#"#include\s*[<"]([^">]+)[>"]"#).expect("Invalid regex");
     }
-    let path = match path.canonicalize() {
-        Ok(path) => path,
-        _ => return vec![],
-    };
     let content = match std::fs::read_to_string(&path) {
         Ok(content) => content,
         _ => return vec![],


### PR DESCRIPTION
To reproduce create a cpp checker as a symlink and have it include a header which is present in the check directory, but not at the location where the link points to. Because of `std::fs::canonicalize` the symlink will get resolved and the compilation will fail. For example g++ compiles the checker correctly.