### PR TITLE
Fix Rust compilation with graders

### DIFF
--- a/task-maker-lang/src/language.rs
+++ b/task-maker-lang/src/language.rs
@@ -228,10 +228,8 @@ impl<'l, 'c> CompiledLanguageBuilder for SimpleCompiledLanguageBuilder<'l, 'c> {
     }
 
     fn finalize(&mut self, dag: &mut ExecutionDAG) -> Result<(Execution, File), Error> {
-        let mut comp = Execution::new(
-            format!("Compilation of {}", self.source_name),
-            self.compiler.clone(),
-        );
+        let name = self.source_path.file_name().unwrap().to_string_lossy();
+        let mut comp = Execution::new(format!("Compilation of {}", name), self.compiler.clone());
         comp.args = self.args.clone();
 
         // compilation dependencies


### PR DESCRIPTION
When compiling Rust files force the name of the source file to be
source.rs inside the sandbox. This way when there's a grader it can
import the solution module with:

```rust
mod source;

fn main() {
    let x = source::thing(42);
}
```

cc: @Virv12 can you try it out and tell me if it works?

Fixes #64