### PR TITLE
Consider communication's solution TLE/MLE/RE for the score

### DIFF
--- a/tests/communication_stdio.rs
+++ b/tests/communication_stdio.rs
@@ -13,16 +13,19 @@ fn communication_stdio(test: TestInterface) {
         .must_compile("solution.c")
         .must_compile("no_output.cpp")
         .must_compile("wrong.cpp")
+        .must_compile("tle.cpp")
         .solution_score("solution.cpp", vec![100.0])
         .solution_score("solution.c", vec![100.0])
         .solution_score("solution.py", vec![100.0])
         .solution_score("no_output.cpp", vec![0.0])
         .solution_score("wrong.cpp", vec![0.0])
+        .solution_score("tle.cpp", vec![0.0])
         .solution_statuses("solution.cpp", vec![Accepted("Ok!".into())])
         .solution_statuses("solution.c", vec![Accepted("Ok!".into())])
         .solution_statuses("solution.py", vec![Accepted("Ok!".into())])
         .solution_statuses("no_output.cpp", vec![WrongAnswer("Ko!".into())])
         .solution_statuses("wrong.cpp", vec![WrongAnswer("Ko!".into())])
+        .solution_statuses("tle.cpp", vec![TimeLimitExceeded])
         .file_exists("check/manager");
 }
 

--- a/tests/tasks/communication_stdio/sol/tle.cpp
+++ b/tests/tasks/communication_stdio/sol/tle.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+
+volatile unsigned long long X;
+
+int main() {
+  int a, b;
+  std::cin >> a >> b;
+  std::cout << a + b << std::endl;
+  for (unsigned long long i = 0;; i++) {
+    X = i + X / 2;
+  }
+}


### PR DESCRIPTION
Previously, if the solution crashed (or timed out) just after providing
the manager the answer, the solution will get the correct outcome
(TLE/MLE/RE), but the score only comes from the manager (including 1.0).

With this patch the score of the solution is the minimum between the
outcome of a solution (which is either nothing if it exits cleanly, or
0.0 if crashes, times out, ...) and the score provided by the manager.

CC: #63