### PR TITLE
Fix AUR package

### DIFF
--- a/tools/aur/task-maker-rust-git/PKGBUILD
+++ b/tools/aur/task-maker-rust-git/PKGBUILD
@@ -23,8 +23,8 @@ pkgver() {
 
 build() {
     cd "$srcdir/task-maker-rust"
-    TM_DATA_DIR=/usr/share/task-maker-rust cargo build --release --bin task-maker
-    cargo run --release --bin task-maker-tools gen-autocompletion
+    TM_DATA_DIR=/usr/share/task-maker-rust cargo build --release --bins
+    target/release/task-maker-tools gen-autocompletion
 }
 
 package() {

--- a/tools/aur/task-maker-rust/PKGBUILD
+++ b/tools/aur/task-maker-rust/PKGBUILD
@@ -14,8 +14,8 @@ sha256sums=('@@SHA256@@')
 
 build() {
     cd "$srcdir/task-maker-rust-${pkgver}"
-    TM_DATA_DIR=/usr/share/task-maker-rust cargo build --release --bin task-maker
-    cargo run --release --bin task-maker-tools gen-autocompletion
+    TM_DATA_DIR=/usr/share/task-maker-rust cargo build --release --bins
+    target/release/task-maker-tools gen-autocompletion
 }
 
 package() {


### PR DESCRIPTION
`task-maker-tools` is compiled without the environment variable `TM_DATA_DIR`