### PR TITLE
Read score_precision from task.yaml and use it in the final ui

### DIFF
--- a/task-maker-format/src/ioi/dag/mod.rs
+++ b/task-maker-format/src/ioi/dag/mod.rs
@@ -116,7 +116,7 @@ mod tests {
             subtasks: Default::default(),
             input_validator_generator: Default::default(),
             testcase_score_aggregator: TestcaseScoreAggregator::Min,
-            score_precision: None,
+            score_precision: 0,
             grader_map: Arc::new(GraderMap::new(Vec::<PathBuf>::new())),
             booklets: vec![],
             difficulty: None,

--- a/task-maker-format/src/ioi/dag/mod.rs
+++ b/task-maker-format/src/ioi/dag/mod.rs
@@ -116,6 +116,7 @@ mod tests {
             subtasks: Default::default(),
             input_validator_generator: Default::default(),
             testcase_score_aggregator: TestcaseScoreAggregator::Min,
+            score_precision: None,
             grader_map: Arc::new(GraderMap::new(Vec::<PathBuf>::new())),
             booklets: vec![],
             difficulty: None,

--- a/task-maker-format/src/ioi/finish_ui.rs
+++ b/task-maker-format/src/ioi/finish_ui.rs
@@ -330,11 +330,11 @@ impl FinishUI {
             .map(|st| st.max_score)
             .sum::<f64>()
             .log10() as usize;
-        task.score_precision.unwrap_or(0) as usize + task_max_score_digits
+        task.score_precision + task_max_score_digits
     }
 
     fn print_summary(&mut self, state: &UIState) {
-        let score_precision = state.task.score_precision.unwrap_or(0) as usize;
+        let score_precision = state.task.score_precision;
         let column_width = score_precision + 4;
         cwriteln!(self, BLUE, "Summary");
         let max_len = FinishUIUtils::get_max_len(&state.evaluations);
@@ -418,13 +418,12 @@ impl FinishUI {
 
     /// Print the score fraction of a solution using colors.
     fn print_score_frac(&mut self, score: f64, max_score: f64, task: &IOITask) {
-        let score_precision = task.score_precision.unwrap_or(0) as usize;
         if max_score == 0.0 {
             print!(
                 "{:.prec$} / {:.prec$}",
                 score,
                 max_score,
-                prec = score_precision
+                prec = task.score_precision
             );
         } else {
             let color = self.score_color(score / max_score);
@@ -434,7 +433,7 @@ impl FinishUI {
                 "{:.prec$} / {:.prec$}",
                 score,
                 max_score,
-                prec = score_precision
+                prec = task.score_precision
             );
         }
     }

--- a/task-maker-format/src/ioi/format/italian_yaml/mod.rs
+++ b/task-maker-format/src/ioi/format/italian_yaml/mod.rs
@@ -326,6 +326,8 @@ struct TaskYAML {
     pub title: String,
     /// The score type to use for this task.
     pub score_type: Option<String>,
+    /// The number of decimal digits when displaying the scores.
+    pub score_precision: Option<u8>,
 
     /// The time limit for the execution of the solutions, if not set it's unlimited.
     #[serde(alias = "timeout")]
@@ -502,6 +504,7 @@ pub fn parse_task<P: AsRef<Path>>(
                     Ok(TestcaseScoreAggregator::Min)
                 }
             })?,
+        score_precision: yaml.score_precision,
         subtasks,
         grader_map,
         booklets: Vec::new(),

--- a/task-maker-format/src/ioi/format/italian_yaml/mod.rs
+++ b/task-maker-format/src/ioi/format/italian_yaml/mod.rs
@@ -327,7 +327,8 @@ struct TaskYAML {
     /// The score type to use for this task.
     pub score_type: Option<String>,
     /// The number of decimal digits when displaying the scores.
-    pub score_precision: Option<u8>,
+    #[serde(default)]
+    pub score_precision: usize,
 
     /// The time limit for the execution of the solutions, if not set it's unlimited.
     #[serde(alias = "timeout")]

--- a/task-maker-format/src/ioi/mod.rs
+++ b/task-maker-format/src/ioi/mod.rs
@@ -128,6 +128,8 @@ pub struct IOITask {
     /// The aggregator to use to compute the score of the subtask based on the score of the
     /// testcases.
     pub testcase_score_aggregator: TestcaseScoreAggregator,
+    /// The number of decimal digits when displaying the scores.
+    pub score_precision: Option<u8>,
     /// The graders registered for this task.
     pub grader_map: Arc<GraderMap>,
     /// The booklets to compile for this task.
@@ -207,6 +209,7 @@ impl IOITask {
             subtasks: Default::default(),
             input_validator_generator: Default::default(),
             testcase_score_aggregator: TestcaseScoreAggregator::Min,
+            score_precision: None,
             grader_map: Arc::new(GraderMap::new::<&Path>(vec![])),
             booklets: vec![],
             difficulty: None,

--- a/task-maker-format/src/ioi/mod.rs
+++ b/task-maker-format/src/ioi/mod.rs
@@ -129,7 +129,8 @@ pub struct IOITask {
     /// testcases.
     pub testcase_score_aggregator: TestcaseScoreAggregator,
     /// The number of decimal digits when displaying the scores.
-    pub score_precision: Option<u8>,
+    #[serde(default)]
+    pub score_precision: usize,
     /// The graders registered for this task.
     pub grader_map: Arc<GraderMap>,
     /// The booklets to compile for this task.
@@ -209,7 +210,7 @@ impl IOITask {
             subtasks: Default::default(),
             input_validator_generator: Default::default(),
             testcase_score_aggregator: TestcaseScoreAggregator::Min,
-            score_precision: None,
+            score_precision: 0,
             grader_map: Arc::new(GraderMap::new::<&Path>(vec![])),
             booklets: vec![],
             difficulty: None,

--- a/task-maker-format/tests/utils.rs
+++ b/task-maker-format/tests/utils.rs
@@ -33,7 +33,7 @@ pub fn new_task_with_context(path: &Path) -> IOITask {
         subtasks: HashMap::new(),
         input_validator_generator: Default::default(),
         testcase_score_aggregator: TestcaseScoreAggregator::Min,
-        score_precision: None,
+        score_precision: 0,
         grader_map: Arc::new(GraderMap::new(Vec::<PathBuf>::new())),
         booklets: vec![],
         difficulty: None,

--- a/task-maker-format/tests/utils.rs
+++ b/task-maker-format/tests/utils.rs
@@ -33,6 +33,7 @@ pub fn new_task_with_context(path: &Path) -> IOITask {
         subtasks: HashMap::new(),
         input_validator_generator: Default::default(),
         testcase_score_aggregator: TestcaseScoreAggregator::Min,
+        score_precision: None,
         grader_map: Arc::new(GraderMap::new(Vec::<PathBuf>::new())),
         booklets: vec![],
         difficulty: None,


### PR DESCRIPTION
If you don't specify `score_precision` in task.yaml the UI looks pretty much identical (with the same score precision used as before). If you pass it, it will be used in some places, but not everywhere, to keep the UI compact.

Fixes #119 