### PR TITLE
Improve solution checks

### DIFF
--- a/task-maker-format/src/ioi/ui_state.rs
+++ b/task-maker-format/src/ioi/ui_state.rs
@@ -6,7 +6,7 @@ use task_maker_dag::*;
 use task_maker_diagnostics::DiagnosticContext;
 use task_maker_exec::ExecutorStatus;
 
-use crate::solution::{SolutionCheck, SolutionCheckResult, SolutionInfo};
+use crate::solution::{SolutionCheck, SolutionInfo, TestcaseEvaluationResult};
 use crate::ui::{CompilationStatus, UIExecutionStatus, UIMessage, UIStateT};
 use crate::{ioi::*, ScoreStatus};
 
@@ -64,22 +64,18 @@ pub enum TestcaseEvaluationStatus {
     Skipped,
 }
 
-impl From<&TestcaseEvaluationStatus> for Option<SolutionCheckResult> {
+impl From<&TestcaseEvaluationStatus> for Option<TestcaseEvaluationResult> {
     fn from(status: &TestcaseEvaluationStatus) -> Self {
+        use TestcaseEvaluationResult as TER;
+        use TestcaseEvaluationStatus as TES;
         match status {
-            TestcaseEvaluationStatus::Accepted(_) => Some(SolutionCheckResult::Accepted),
-            TestcaseEvaluationStatus::Partial(_) => Some(SolutionCheckResult::PartialScore),
-            TestcaseEvaluationStatus::WrongAnswer(_) => Some(SolutionCheckResult::WrongAnswer),
-            TestcaseEvaluationStatus::TimeLimitExceeded => {
-                Some(SolutionCheckResult::TimeLimitExceeded)
-            }
-            TestcaseEvaluationStatus::WallTimeLimitExceeded => {
-                Some(SolutionCheckResult::TimeLimitExceeded)
-            }
-            TestcaseEvaluationStatus::MemoryLimitExceeded => {
-                Some(SolutionCheckResult::MemoryLimitExceeded)
-            }
-            TestcaseEvaluationStatus::RuntimeError => Some(SolutionCheckResult::RuntimeError),
+            TES::Accepted(_) => Some(TER::Accepted),
+            TES::Partial(_) => Some(TER::Partial),
+            TES::WrongAnswer(_) => Some(TER::WrongAnswer),
+            TES::TimeLimitExceeded => Some(TER::TimeLimitExceeded),
+            TES::WallTimeLimitExceeded => Some(TER::WallTimeLimitExceeded),
+            TES::MemoryLimitExceeded => Some(TER::MemoryLimitExceeded),
+            TES::RuntimeError => Some(TER::RuntimeError),
             _ => None,
         }
     }
@@ -392,7 +388,7 @@ impl UIState {
                     }
                     let solution_result = solution_result.unwrap();
                     let subtask_result = &solution_result.subtasks[&subtask.id];
-                    let testcase_results: Vec<Option<SolutionCheckResult>> = subtask_result
+                    let testcase_results: Vec<Option<TestcaseEvaluationResult>> = subtask_result
                         .testcases
                         .values()
                         .map(|testcase| (&testcase.status).into())

--- a/task-maker-format/src/solution.rs
+++ b/task-maker-format/src/solution.rs
@@ -103,6 +103,7 @@ impl SolutionCheck {
 }
 
 /// Result of the evaluation of a solution on a testcase.
+///
 /// We define a partial order used to determine the correctness of solution checks.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum TestcaseEvaluationResult {
@@ -196,7 +197,7 @@ impl FromStr for SolutionCheckResult {
 }
 
 impl SolutionCheckResult {
-    /// List all SolutionCheckResult sorted by self.minimals().len()
+    /// List all [`SolutionCheckResult`] sorted by self.minimals().len().
     pub fn sorted_all() -> &'static [Self] {
         &[
             Self::Accepted,


### PR DESCRIPTION
Rewrite a good part of solution checks.

We introduce a distinction between `TestcaseEvaluationStatus`, `TestcaseEvaluationResult` and `SolutionCheckResult`. The first describes the status of a solution during and after evaluation, the second describes the result of a solution *after* evaluation thus it's a strict subset of the first, and the last describe a solution check.

We define a partial order on `TestcaseEvaluationResult` based on the corresponding scoring.

Each `SolutionCheckResult` is described by:
* a long name (`SolutionCheckResult::as_str`)
* a short name (`SolutionCheckResult::as_compact_str`)
* a set of `TestcaseEvaluationResult` (`SolutionCheckResult::minimals`)

We say that `outcomes: [TestcaseEvaluationResult]` satisfies a `sol_check: SolutionCheckResult` iff there
exists a minimal element `min` of `outcomes` such that `min` is contained in `sol_check.minimals()`.

To automatically add solution checks to a subtask with outcomes `outcomes: [TestcaseEvaluationResult]` we find the `check: SolutionCheckResult` corresponding to the smallest `check.minimals()` such that all minimal elements of `outcomes` are contained in `check.minimals()`.

I also added `check-wall-time-limit-exceeded`.

#### Differences with the old model:
* `add-solution-checks` works with partial scores.
* `add-solution-checks` prefers `check-zero` over multiple checks such as `check-time-limit-exceeded`, `check-runtime-error`, etc...
* The old model handles everything case by case leading to confusing code and bugs, now everything is handled by a single confusing case.

#### Unsolved problems
* `check-partial-score` is too generic, it would be better to specify a range of possible scores but this would imply an infinite amount of elements for `TestcaseEvaluationResult` which can't be handled by the proposed model.
* solution checks work poorly with task with `score_mode: sum`.