### PR TITLE
Fix the checker fuzzer.

### DIFF
--- a/src/tools/fuzz_checker/checker_header.h
+++ b/src/tools/fuzz_checker/checker_header.h
@@ -5,4 +5,8 @@
 #define _exit EXIT
 #define exit EXIT
 
-[[noreturn]] void EXIT(int status);
+struct Exit {
+  int status;
+};
+
+[[noreturn]] inline void EXIT(int status) { throw Exit{status}; }

--- a/src/tools/fuzz_checker/fuzzer.cpp
+++ b/src/tools/fuzz_checker/fuzzer.cpp
@@ -20,8 +20,6 @@ struct Exit {
   int status;
 };
 
-[[noreturn]] void EXIT(int status) { throw Exit{status}; }
-
 #ifndef NUM_INPUTS
 #error Missing NUM_INPUTS
 #endif


### PR DESCRIPTION
EXIT() needs to be defined in `checker.so`, not in the binary that `dlopen`s it.