### PR TITLE
Support cms names for score_type

### DIFF
--- a/task-maker-format/src/ioi/mod.rs
+++ b/task-maker-format/src/ioi/mod.rs
@@ -521,8 +521,9 @@ impl FromStr for TestcaseScoreAggregator {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "min" => Ok(TestcaseScoreAggregator::Min),
-            "sum" => Ok(TestcaseScoreAggregator::Sum),
+            "min" | "GroupMin" => Ok(TestcaseScoreAggregator::Min),
+            "sum" | "Sum" => Ok(TestcaseScoreAggregator::Sum),
+            "GroupMul" | "GroupThreshold" => bail!("{s} is not supported yet"),
             _ => bail!("Invalid testcase score aggregator: {}", s),
         }
     }


### PR DESCRIPTION
cms and tmr are using different names for `score_types`' values. This PR improves the compatibility of the two programs.