### PR TITLE
fixed find_bad_case not working

### DIFF
--- a/src/tools/find_bad_case/dag.rs
+++ b/src/tools/find_bad_case/dag.rs
@@ -99,6 +99,7 @@ pub fn patch_task_for_batch(
                 input_validator: task.input_validator_generator.generate(Some(0)),
                 ..Default::default()
             };
+            task.testcases = testcases;
             task.subtasks.insert(0, subtask);
         }
         TaskFormat::Terry(_) => {


### PR DESCRIPTION
Fixes `task-maker-tools find-bad-case`, missing tests.