### PR TITLE
Faster cache

### DIFF
--- a/task-maker-cache/src/entry.rs
+++ b/task-maker-cache/src/entry.rs
@@ -64,7 +64,11 @@ impl CacheEntryItem {
             .map(|(path, file)| (path.clone(), file_keys[&file.uuid].key().clone()))
             .collect();
         CacheEntryItem {
-            result,
+            result: ExecutionResult {
+                stdout: None,
+                stderr: None,
+                ..result
+            },
             limits: execution.limits.clone(),
             stdout,
             stderr,


### PR DESCRIPTION
The cache index won't store solution stdout and stderr anymore, reducing its size by up to 4 orders of magnitude 